### PR TITLE
Hotreload of player-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/**/__pycache__/
 venv/
 **/.vagrant/
 data/
+ataka-player-cli.pyz

--- a/ataka/api/Dockerfile
+++ b/ataka/api/Dockerfile
@@ -12,16 +12,10 @@ COPY ataka/common /ataka/common
 
 VOLUME /data/shared
 VOLUME /data/exploits
+VOLUME /ataka/player-cli
 
 COPY ataka/api/requirements.txt /ataka/api/
 RUN pip install --no-cache-dir -r /ataka/api/requirements.txt
 COPY ataka/api /ataka/api
-
-COPY ataka/player-cli/requirements.txt /ataka/player-cli/
-RUN pip install --no-cache-dir -r /ataka/player-cli/requirements.txt
-COPY ataka/player-cli /ataka/player-cli
-
-COPY "ataka/ctfconfig/$CTF.py" /ataka/player-cli/player_cli/ctfconfig.py
-RUN python -m zipapp /ataka/player-cli
 
 CMD [ "bash", "/ataka/common/delayed_start.sh", "--", "python", "-m", "uvicorn", "--reload", "--host", "0.0.0.0", "ataka.api:app"]

--- a/ataka/api/__init__.py
+++ b/ataka/api/__init__.py
@@ -55,7 +55,7 @@ def get_channel():
 
 @app.get("/")
 async def get_playercli(session: Session = Depends(get_session)):
-    return FileResponse(path="/ataka/player-cli.pyz", filename="ataka-player-cli.pyz")
+    return FileResponse(path="/ataka/player-cli/ataka-player-cli.pyz", filename="ataka-player-cli.pyz")
 
 @app.get("/api/targets")
 async def all_targets(session: Session = Depends(get_session)):

--- a/ataka/ctfcode/Dockerfile
+++ b/ataka/ctfcode/Dockerfile
@@ -9,6 +9,7 @@ RUN pip install --no-cache-dir -r /ataka/common/requirements.txt
 COPY ataka/common /ataka/common
 
 VOLUME /ataka/ctfconfig
+VOLUME /ataka/player-cli
 VOLUME /data/shared
 
 COPY ataka/ctfcode/requirements.txt /ataka/ctfcode/
@@ -16,4 +17,3 @@ RUN pip install --no-cache-dir -r /ataka/ctfcode/requirements.txt
 COPY ataka/ctfcode /ataka/ctfcode
 
 CMD [ "bash", "/ataka/common/delayed_start.sh", "--", "python", "-m", "ataka.ctfcode" ]
-

--- a/ataka/ctfconfig/iccdemo.py
+++ b/ataka/ctfconfig/iccdemo.py
@@ -45,6 +45,9 @@ except ImportError as e:
         # be working. Flags that are rejected might be sent again!
         SERVICEBROKEN = 'servicebroken'
 
+# Ataka Host Domain / IP
+ATAKA_HOST = 'ataka.local'
+
 # Our own host
 OWN_HOST = '10.60.4.1'
 

--- a/ataka/ctfconfig/testctf.py
+++ b/ataka/ctfconfig/testctf.py
@@ -43,6 +43,8 @@ except ImportError as e:
         # be working. Flags that are rejected might be sent again!
         SERVICEBROKEN = 'servicebroken'
 
+# Ataka Host Domain / IP
+ATAKA_HOST = 'ataka.local'
 
 # Our own host
 OWN_HOST = ''
@@ -54,7 +56,7 @@ ROUND_TIME = 10
 
 # format: regex, group where group 0 means the whole regex
 FLAG_REGEX = r"[A-Z0-9]{31}=", 0
-FLAG_REGEX = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}", 0
+#FLAG_REGEX = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}", 0
 
 FLAG_BATCHSIZE = 100
 

--- a/ataka/player-cli/player_cli/ctfconfig.py
+++ b/ataka/player-cli/player_cli/ctfconfig.py
@@ -1,5 +1,4 @@
 import logging
-from random import random
 
 try:
     from ataka.common.database.models import FlagStatus
@@ -44,6 +43,8 @@ except ImportError as e:
         # be working. Flags that are rejected might be sent again!
         SERVICEBROKEN = 'servicebroken'
 
+# Ataka Host Domain / IP
+ATAKA_HOST = 'api.ataka.local'
 
 # Our own host
 OWN_HOST = ''
@@ -114,10 +115,7 @@ RESPONSES = {
 
 
 def submit_flags(flags):
-    if(random() > 0.5):
-        return [FlagStatus.OK for flag in flags]
-    else:
-        return [FlagStatus.INVALID for flag in flags]
+    return [FlagStatus.OK for flag in flags]
 
 
 """
@@ -150,3 +148,7 @@ def submit_flags(flags):
         logger.error("Exception during flag submission: {} -> {}".format(str(r.status_code), str(r.text)))
         return FlagStatus.ERROR
 """
+
+
+def scrape_scoreboard():
+    return []

--- a/ataka/player-cli/player_cli/root.py
+++ b/ataka/player-cli/player_cli/root.py
@@ -1,9 +1,7 @@
 import typer
+import requests
+import sys
 import player_cli
-
-
-DEFAULT_HOST = 'ataka.h4xx.eu'
-
 
 app = typer.Typer()
 
@@ -14,10 +12,9 @@ app.add_typer(player_cli.cmd_service.app,
 app.add_typer(player_cli.cmd_flag.app,
               name='flag', help='Manage flags.')
 
-
 @app.callback()
 def main(
-    host: str = typer.Option('ataka.h4xx.eu', '--host', '-h',
+    host: str = typer.Option(player_cli.ctfconfig_wrapper.ATAKA_HOST, '--host', '-h',
         help='Ataka web API host.'),
     bypass_tools: bool = typer.Option(False, '--bypass-tools', '-b', help=
         'Interact directly with the gameserver instead of using our tools. '
@@ -28,3 +25,15 @@ def main(
     """
     player_cli.state['host'] = host
     player_cli.state['bypass_tools'] = bypass_tools
+
+@app.command('reload', help='Reload offline ctfconfig')
+def reloadConfig():
+    cli_path = sys.argv[0]
+    resp = requests.get(f"http://{player_cli.state['host']}/")
+
+    if resp.status_code != 200:
+        print(f"{player_cli.state['host']} returned {resp.status_code}")
+        return
+
+    with open(cli_path, 'wb') as f:
+        f.write(resp.content)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     volumes:
       - ${DATA_STORE}/shared:/data/shared:rw,z
       - ${DATA_STORE}/exploits:/data/exploits:rw,z
+      - ./ataka/player-cli:/ataka/player-cli:ro
       - ./ataka/api:/ataka/api
     expose:
       - "8000"
@@ -97,6 +98,7 @@ services:
       dockerfile: ataka/ctfcode/Dockerfile
     volumes:
       - ./ataka/ctfconfig:/ataka/ctfconfig:ro
+      - ./ataka/player-cli:/ataka/player-cli:rw,z
       - ${DATA_STORE}/shared:/data/shared:rw,z
     security_opt:
       - label:disable


### PR DESCRIPTION
- Added ATAKA_HOST in ctfconfig
- When hot reloading ataka (`./ataka-cli reload`) the `ataka-player-cli.pyz` gets repackeged.
- The players can reload their local instance by running the player-cli (`atk reload`)