### PR TITLE
player-cli: Show help by default when no arguments are given

### DIFF
--- a/ataka/player-cli/player_cli/__init__.py
+++ b/ataka/player-cli/player_cli/__init__.py
@@ -14,7 +14,7 @@ state = {
     'debug': False
 }
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 app.add_typer(player_cli.exploit.app,
               name='exploit', help='Manage exploits.')

--- a/ataka/player-cli/player_cli/exploit/__init__.py
+++ b/ataka/player-cli/player_cli/exploit/__init__.py
@@ -41,7 +41,7 @@ app.add_typer(target.app, name='target', help='Manage exploit targets.')
 def exploit_ls(
         history_ids: List[str] = typer.Argument(None, help='History ID(s).')
 ):
-    histories = resolve_history(history_ids) if len(history_ids) > 0 else get_all_histories()
+    histories = resolve_history(history_ids) if history_ids is not None and len(history_ids) > 0 else get_all_histories()
 
     if len(histories) == 0:
         print("No exploits found")

--- a/ataka/player-cli/player_cli/exploit/__init__.py
+++ b/ataka/player-cli/player_cli/exploit/__init__.py
@@ -32,7 +32,7 @@ from .job import run_local_job
 from .target import get_targets
 from ..flags import poll_and_show_flags
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 app.add_typer(target.app, name='target', help='Manage exploit targets.')
 
@@ -51,7 +51,7 @@ def exploit_ls(
         print_history(history)
 
 
-@app.command('activate', help='Activate an exploit.')
+@app.command('activate', help='Activate an exploit.', no_args_is_help=True)
 def exploit_activate(
         exploit_id: str = typer.Argument(..., help=
         'Exploit ID or history ID. '
@@ -63,7 +63,7 @@ def exploit_activate(
     return activate_exploit(exploit)
 
 
-@app.command('deactivate', help='Deactivate an exploit.')
+@app.command('deactivate', help='Deactivate an exploit.', no_args_is_help=True)
 def exploit_deactivate(
         exploit_id: str = typer.Argument(..., help=
         'Exploit ID or history ID. '
@@ -75,7 +75,7 @@ def exploit_deactivate(
 
 
 @app.command('switch', help=
-'Activate an exploit and deactivate all others in the history.')
+'Activate an exploit and deactivate all others in the history.', no_args_is_help=True)
 def exploit_switch(
         exploit_id: str = typer.Argument(..., help='Exploit ID.')
 ):
@@ -94,7 +94,7 @@ def exploit_switch(
     deactivate_history(history)
     activate_exploit(exploit)
 
-@app.command('create', help='Create an exploit history.')
+@app.command('create', help='Create an exploit history.', no_args_is_help=True)
 def exploit_create(
         history_id: str = typer.Argument(..., help='History ID (the "friendly" exploit name).'),
         service: str = typer.Argument(..., help='The target service.')
@@ -114,7 +114,7 @@ def exploit_create(
     print(f"Exploit history {history_id} created!")
 
 
-@app.command('logs', help='Show remote exploit logs.')
+@app.command('logs', help='Show remote exploit logs.', no_args_is_help=True)
 def exploit_logs(
         cmd_ids: List[str] = typer.Argument(..., metavar='EXPLOIT_ID...', help=
         'Exploit ID or history ID. '
@@ -129,7 +129,7 @@ def exploit_logs(
     print_logs(exploits, limit)
 
 
-@app.command('upload', help='Upload an exploit.')
+@app.command('upload', help='Upload an exploit.', no_args_is_help=True)
 def exploit_upload(
         history_id: str = typer.Argument(..., help='History ID (the "friendly" exploit name).'),
         author: str = typer.Argument(..., help='The author.'),
@@ -218,7 +218,7 @@ def exploit_upload(
         print(f"Afterwards use `{sys.argv[0]} exploit switch {exploit_id}` to switch over central execution")
 
 
-@app.command('download', help='Download an exploit.')
+@app.command('download', help='Download an exploit.', no_args_is_help=True)
 def exploit_download(
         exploit_id: str = typer.Argument(..., help='Exploit ID.'),
         path: str = typer.Argument(..., help='Output directory (will be created).'),
@@ -260,7 +260,7 @@ def exploit_download(
 self_as_zip_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
-@app.command("template", help="Generate an exploit stub from a template.")
+@app.command("template", help="Generate an exploit stub from a template.", no_args_is_help=True)
 def exploit_template(
         template: str = typer.Argument(
             ...,
@@ -318,7 +318,7 @@ def exploit_template(
     print(f'Created exploit "{path}/" from template {template}:{tag}')
 
 
-@app.command('runlocal', help='Run an exploit locally.')
+@app.command('runlocal', help='Run an exploit locally.', no_args_is_help=True)
 def exploit_runlocal(
         path: str = typer.Argument(..., help=
         'Path to exploit executable, or to a directory containing a Dockerfile. '

--- a/ataka/player-cli/player_cli/exploit/target.py
+++ b/ataka/player-cli/player_cli/exploit/target.py
@@ -6,7 +6,7 @@ from player_cli.ctfconfig_wrapper import STATIC_EXCLUSIONS, RUNLOCAL_TARGETS, RO
 from .exploit import resolve_history, resolve_exploit
 from player_cli.util import request, greenify, redify, WARN_STR, ERROR_STR
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 
 def print_exploit_targets(history, indent=0):
@@ -60,7 +60,7 @@ def get_targets(service, all_targets=True, target_ips=RUNLOCAL_TARGETS, no_targe
     return [t for t in targets if t['ip'] not in no_target_ips]
 
 
-@app.command('ls', help='List exploit targets.')
+@app.command('ls', help='List exploit targets.', no_args_is_help=True)
 def exploit_target_ls(
         history_id: str = typer.Argument(..., help='History ID.')
 ):
@@ -115,7 +115,7 @@ def _exploit_target_on_off(history_id: str, target_ips: List[str], all_flag: boo
     print_exploit_targets(history)
 
 
-@app.command('on', help='Turn on exploit targets.')
+@app.command('on', help='Turn on exploit targets.', no_args_is_help=True)
 def exploit_target_on(
         history_id: str = typer.Argument(..., help='History ID.'),
         target_ips: List[str] = typer.Argument(None, help='Target IP(s).'),
@@ -135,7 +135,7 @@ def exploit_target_on(
     })
     print(f"Created job {job['id']} for targets {', '.join([target['ip'] for target in targets])}")
 
-@app.command('off', help='Turn off exploit targets.')
+@app.command('off', help='Turn off exploit targets.', no_args_is_help=True)
 def exploit_target_off(
         history_id: str = typer.Argument(..., help='History ID.'),
         target_ips: List[str] = typer.Argument(None, help='Target IP(s).'),

--- a/ataka/player-cli/player_cli/exploit/target.py
+++ b/ataka/player-cli/player_cli/exploit/target.py
@@ -121,6 +121,7 @@ def exploit_target_on(
         target_ips: List[str] = typer.Argument(None, help='Target IP(s).'),
         all_flag: bool = typer.Option(False, '--all', help='Turn on all targets.')
 ):
+    target_ips = target_ips if target_ips is not None else []
     _exploit_target_on_off(history_id, target_ips, all_flag, True, True)
 
     exploit = resolve_exploit(history_id)
@@ -143,4 +144,5 @@ def exploit_target_off(
         force: bool = typer.Option(False, '--force', help=
         'Allow exclusion of unknown targets.')
 ):
+    target_ips = target_ips if target_ips is not None else []
     _exploit_target_on_off(history_id, target_ips, all_flag, force, False)

--- a/ataka/player-cli/player_cli/flags.py
+++ b/ataka/player-cli/player_cli/flags.py
@@ -11,7 +11,7 @@ from player_cli.ctfconfig_wrapper import RUNLOCAL_TARGETS
 from player_cli.exploit import get_targets
 from player_cli.util import request, ERROR_STR, magentify, greenify, blueify, redify, yellowfy
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 FLAG_STATUS_IS_FINAL = {'ok', 'duplicate', 'duplicate_not_submitted', 'nop', 'ownflag', 'inactive', 'invalid'}
 

--- a/ataka/player-cli/player_cli/service.py
+++ b/ataka/player-cli/player_cli/service.py
@@ -5,7 +5,7 @@ import typer
 from player_cli.exploit.target import get_targets
 from player_cli.util import magentify
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 @app.command('ls', help='List services (legacy)')
 def service_ls():


### PR DESCRIPTION
Makes the tool more explorable without requiring --help all the time.