### PR TITLE
Interactive prompt for existing exploits

### DIFF
--- a/ataka/player-cli/player_cli/exploit/__init__.py
+++ b/ataka/player-cli/player_cli/exploit/__init__.py
@@ -245,15 +245,20 @@ def exploit_download(
                         print(f'{ERROR_STR}: unsafe archive: link detected')
                         raise typer.Exit(code=1)
 
-            try:
-                os.mkdir(path)
-            except FileExistsError:
-                if overwrite:
-                    print(f'{WARN_STR}: directory "{path}" already exists (proceeding anyway)')
-                else:
-                    print(f'{ERROR_STR}: directory "{path}" already exists (use --overwrite to proceed anyway)')
+            # Check if the directory already exists and ask the user if 
+            # overwriting is fine if overwrite is not explicitly specified
+            if os.path.exists(path) and not overwrite:
+                confirm_str = (
+                    f'{ERROR_STR}: directory "{path}" already exists, '
+                    'do you want to overwrite it?'
+                )
+                overwrite_answer = Confirm.ask(confirm_str)
+                if not overwrite_answer:
                     raise typer.Exit(code=1)
 
+            # Recursivly create directories, not raising FileExistsError on
+            # existing directories(overwrite-case)
+            os.makedirs(path, exist_ok=True)
             tar.extractall(path)
 
 

--- a/ataka/player-cli/player_cli/exploit/__init__.py
+++ b/ataka/player-cli/player_cli/exploit/__init__.py
@@ -248,10 +248,8 @@ def exploit_download(
             # Check if the directory already exists and ask the user if 
             # overwriting is fine if overwrite is not explicitly specified
             if os.path.exists(path) and not overwrite:
-                confirm_str = (
-                    f'{ERROR_STR}: directory "{path}" already exists, '
-                    'do you want to overwrite it?'
-                )
+                confirm_str = f'{ERROR_STR}: directory "{path}" already exists, do you want to overwrite it?'
+
                 overwrite_answer = Confirm.ask(confirm_str)
                 if not overwrite_answer:
                     raise typer.Exit(code=1)


### PR DESCRIPTION
This PR adds an interactive prompt that explicitly asks if an exploit should be overwritten if it already exists.
If `--overwrite` gets specified, this prompt is not shown.